### PR TITLE
Fixed valueEncoding in deletion bug

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -36,7 +36,7 @@ Node.prototype.path = function (i) {
 
 Node.prototype.encode = function () {
   this.trieBuffer = trie.encode(this.trie)
-  this.valueBuffer = this.valueEncoding ? this.valueEncoding.encode(this.value) : this.value
+  this.valueBuffer = ((this.value !== null) && this.valueEncoding) ? this.valueEncoding.encode(this.value) : this.value
   return messages.Node.encode(this)
 }
 

--- a/test/deletes.js
+++ b/test/deletes.js
@@ -1,6 +1,8 @@
 const tape = require('tape')
 const create = require('./helpers/create')
 
+const messages = require('../lib/messages')
+
 tape('basic delete', function (t) {
   const db = create()
 
@@ -127,6 +129,22 @@ tape('delete many in many (iteration)', function (t) {
       ite.next(loop)
     })
   }
+})
+
+tape('deletion with a single record, and a valueEncoding', function (t) {
+  const db = create(null, { valueEncoding: messages.Header })
+
+  db.put('hello', { type: 'some-type' }, function (err) {
+    t.error(err, 'no error')
+    db.del('hello', function (err) {
+      t.error(err, 'no error')
+      db.get('hello', function (err, val) {
+        t.error(err, 'no error')
+        t.same(val, null)
+        t.end()
+      })
+    })
+  })
 })
 
 function toDel (e) {

--- a/test/helpers/create.js
+++ b/test/helpers/create.js
@@ -2,9 +2,6 @@ const ram = require('random-access-memory')
 const hypertrie = require('../../')
 
 module.exports = function (key, opts) {
-  opts = {
-    valueEncoding: 'json',
-    ...opts
-  }
+  opts = Object.assign({ valueEncoding: 'json' }, opts)
   return hypertrie(ram, key, opts)
 }

--- a/test/helpers/create.js
+++ b/test/helpers/create.js
@@ -1,6 +1,10 @@
 const ram = require('random-access-memory')
 const hypertrie = require('../../')
 
-module.exports = function (key) {
-  return hypertrie(ram, key, {valueEncoding: 'json'})
+module.exports = function (key, opts) {
+  opts = {
+    valueEncoding: 'json',
+    ...opts
+  }
+  return hypertrie(ram, key, opts)
 }


### PR DESCRIPTION
When there's only a single node in the trie, deletion will attempt to insert a null object, which will currently be encoded according to the specified `valueEncoding`. The deletion tests pass because we're using a JSON encoding, which can encode `null`. Were we using a protobuf, for example, the tests would fail.

Also included a test to check for this condition.