### PR TITLE
Add options handling + conditions to put/del

### DIFF
--- a/index.js
+++ b/index.js
@@ -169,12 +169,21 @@ HyperTrie.prototype.batch = function (ops, cb) {
   return new Batch(this, ops, cb || noop)
 }
 
-HyperTrie.prototype.put = function (key, value, cb) {
-  return new Put(this, key, value, null, 0, cb || noop)
+HyperTrie.prototype.put = function (key, value, opts, cb) {
+  if (typeof opts === 'function') return this.put(key, value, null, opts)
+  opts = Object.assign({}, opts, {
+    batch: null,
+    del: 0
+  })
+  return new Put(this, key, value, opts, cb || noop)
 }
 
-HyperTrie.prototype.del = function (key, cb) {
-  return new Delete(this, key, null, cb)
+HyperTrie.prototype.del = function (key, opts, cb) {
+  if (typeof opts === 'function') return this.del(key, null, opts)
+  opts = Object.assign({}, opts, {
+    batch: null
+  })
+  return new Delete(this, key, opts, cb)
 }
 
 HyperTrie.prototype.createWriteStream = function (opts) {

--- a/lib/batch.js
+++ b/lib/batch.js
@@ -71,7 +71,7 @@ Batch.prototype._update = function () {
     if (head) self._head = head
 
     const {type, key, value} = self._ops[i++]
-    if (type === 'del') self._op = new Delete(self._db, key, self, loop)
-    else self._op = new Put(self._db, key, value === undefined ? null : value, self, 0, loop)
+    if (type === 'del') self._op = new Delete(self._db, key, { batch: self }, loop)
+    else self._op = new Put(self._db, key, value === undefined ? null : value, { batch: self, del: 0 }, loop)
   }
 }

--- a/lib/del.js
+++ b/lib/del.js
@@ -3,13 +3,14 @@ const Node = require('./node')
 
 module.exports = Delete
 
-function Delete (db, key, batch, cb) {
+function Delete (db, key, opts, cb) {
   this._db = db
   this._key = key
   this._callback = cb
   this._release = null
   this._put = null
-  this._batch = batch
+  this._batch = opts.batch
+  this._condition = opts.condition
   this._node = new Node({key})
   this._length = this._node.length
   this._closest = 0
@@ -47,7 +48,19 @@ Delete.prototype._splice = function (closest, node) {
   const val = closest ? closest.value : null
   const self = this
 
-  this._put = new Put(this._db, key, val, this._batch, node.seq, done)
+  if (this._condition) {
+    this._condition(node.value, (err, proceed) => {
+      if (err) return done(err)
+      if (!proceed) return done(null)
+      return del()
+    })
+  } else {
+    return del()
+  }
+
+  function del () {
+    self._put = new Put(self._db, key, val, { batch: self._batch, del: node.seq }, done)
+  }
 
   function done (err, node) {
     self._finalize(err, node)

--- a/lib/del.js
+++ b/lib/del.js
@@ -48,10 +48,10 @@ Delete.prototype._splice = function (closest, node) {
   const val = closest ? closest.value : null
   const self = this
 
-  if (this._condition) this._condition(node.value, onCondition)
+  if (this._condition) this._condition(node.value, oncondition)
   else del()
 
-  function onCondition (err, proceed) {
+  function oncondition (err, proceed) {
     if (err) return done(err)
     if (!proceed) return done(null)
     return del()

--- a/lib/del.js
+++ b/lib/del.js
@@ -3,7 +3,7 @@ const Node = require('./node')
 
 module.exports = Delete
 
-function Delete (db, key, { batch = null, condition = null }, cb) {
+function Delete (db, key, { batch, condition = null }, cb) {
   this._db = db
   this._key = key
   this._callback = cb

--- a/lib/del.js
+++ b/lib/del.js
@@ -3,14 +3,14 @@ const Node = require('./node')
 
 module.exports = Delete
 
-function Delete (db, key, opts, cb) {
+function Delete (db, key, { batch = null, condition = null }, cb) {
   this._db = db
   this._key = key
   this._callback = cb
   this._release = null
   this._put = null
-  this._batch = opts.batch
-  this._condition = opts.condition
+  this._batch = batch
+  this._condition = condition
   this._node = new Node({key})
   this._length = this._node.length
   this._closest = 0
@@ -48,13 +48,12 @@ Delete.prototype._splice = function (closest, node) {
   const val = closest ? closest.value : null
   const self = this
 
-  if (this._condition) {
-    this._condition(node.value, (err, proceed) => {
-      if (err) return done(err)
-      if (!proceed) return done(null)
-      return del()
-    })
-  } else {
+  if (this._condition) this._condition(node.value, onCondition)
+  else del()
+
+  function onCondition (err, proceed) {
+    if (err) return done(err)
+    if (!proceed) return done(null)
     return del()
   }
 

--- a/lib/put.js
+++ b/lib/put.js
@@ -49,10 +49,10 @@ Put.prototype._finalize = function (err, lastNode) {
   if (this._error) err = this._error
   if (err) return done(err)
 
-  if (this._condition) this._condition(lastNode, this._node, onCondition)
+  if (this._condition) this._condition(lastNode, this._node, oncondition)
   else insert()
 
-  function onCondition (err, proceed) {
+  function oncondition (err, proceed) {
     if (err) return done(err)
     if (!proceed) return done(null)
     return insert()

--- a/lib/put.js
+++ b/lib/put.js
@@ -2,7 +2,7 @@ const Node = require('./node')
 
 module.exports = Put
 
-function Put (db, key, value, { batch = null, del = null, condition = null }, cb) {
+function Put (db, key, value, { batch = null, del = 0, condition = null }, cb) {
   this._db = db
   this._node = new Node({key, value}, 0, db.valueEncoding)
   this._callback = cb

--- a/lib/put.js
+++ b/lib/put.js
@@ -2,7 +2,7 @@ const Node = require('./node')
 
 module.exports = Put
 
-function Put (db, key, value, { batch = null, del = 0, condition = null }, cb) {
+function Put (db, key, value, { batch, del, condition = null }, cb) {
   this._db = db
   this._node = new Node({key, value}, 0, db.valueEncoding)
   this._callback = cb

--- a/lib/put.js
+++ b/lib/put.js
@@ -2,16 +2,16 @@ const Node = require('./node')
 
 module.exports = Put
 
-function Put (db, key, value, opts, cb) {
+function Put (db, key, value, { batch = null, del = null, condition = null }, cb) {
   this._db = db
   this._node = new Node({key, value}, 0, db.valueEncoding)
   this._callback = cb
   this._release = null
-  this._batch = opts.batch
-  this._condition = opts.condition
+  this._batch = batch
+  this._condition = condition
   this._error = null
   this._pending = 0
-  this._del = opts.del
+  this._del = del
   this._finalized = false
 
   if (this._batch) this._update(0, this._batch.head())
@@ -49,13 +49,12 @@ Put.prototype._finalize = function (err, lastNode) {
   if (this._error) err = this._error
   if (err) return done(err)
 
-  if (this._condition) {
-    this._condition(lastNode, this._node, (err, proceed) => {
-      if (err) return done(err)
-      if (!proceed) return done(null)
-      return insert()
-    })
-  } else {
+  if (this._condition) this._condition(lastNode, this._node, onCondition)
+  else insert()
+
+  function onCondition (err, proceed) {
+    if (err) return done(err)
+    if (!proceed) return done(null)
     return insert()
   }
 

--- a/lib/put.js
+++ b/lib/put.js
@@ -2,15 +2,16 @@ const Node = require('./node')
 
 module.exports = Put
 
-function Put (db, key, value, batch, del, cb) {
+function Put (db, key, value, opts, cb) {
   this._db = db
   this._node = new Node({key, value}, 0, db.valueEncoding)
   this._callback = cb
   this._release = null
-  this._batch = batch
+  this._batch = opts.batch
+  this._condition = opts.condition
   this._error = null
   this._pending = 0
-  this._del = del
+  this._del = opts.del
   this._finalized = false
 
   if (this._batch) this._update(0, this._batch.head())
@@ -36,7 +37,7 @@ Put.prototype._start = function () {
   }
 }
 
-Put.prototype._finalize = function (err) {
+Put.prototype._finalize = function (err, lastNode) {
   const self = this
 
   this._finalized = true
@@ -48,13 +49,25 @@ Put.prototype._finalize = function (err) {
   if (this._error) err = this._error
   if (err) return done(err)
 
-  if (this._batch) {
-    this._batch.append(this._node)
-    return done(null, this._node)
+  if (this._condition) {
+    this._condition(lastNode, this._node, (err, proceed) => {
+      if (err) return done(err)
+      if (!proceed) return done(null)
+      return insert()
+    })
+  } else {
+    return insert()
   }
 
-  this._node.seq = this._db.feed.length
-  this._db.feed.append(this._node.encode(), done)
+  function insert () {
+    if (self._batch) {
+      self._batch.append(self._node)
+      return done(null, self._node)
+    }
+
+    self._node.seq = self._db.feed.length
+    self._db.feed.append(self._node.encode(), done)
+  }
 
   function done (err) {
     const node = err ? null : self._node
@@ -118,7 +131,7 @@ Put.prototype._update = function (i, head) {
     return this._updateHead(i, seq)
   }
 
-  this._finalize(null)
+  this._finalize(null, head)
 }
 
 Put.prototype._get = function (seq, cb) {

--- a/test/conditions.js
+++ b/test/conditions.js
@@ -1,0 +1,94 @@
+const tape = require('tape')
+const create = require('./helpers/create')
+
+tape('condition: put only if changed', function (t) {
+  const db = create()
+  db.put('hello', 'world', { condition: onlyIfChanged }, err => {
+    t.error(err, 'no error')
+    db.put('hello', 'world', { condition: onlyIfChanged }, err => {
+      t.error(err, 'no error')
+      t.same(db.version, 2)
+      t.end()
+    })
+  })
+
+  function onlyIfChanged (oldNode, newNode, cb) {
+    if (!oldNode) return cb(null, true)
+    if (oldNode && !newNode) return cb(new Error('Cannot insert a null value (use delete)'))
+    if (oldNode.value === newNode.value) return cb(null, false)
+    return cb(null, true)
+  }
+})
+
+tape('condition: put only if the value is null', function (t) {
+  const db = create()
+  db.put('hello', 'world', { condition: onlyIfNull }, err => {
+    t.error(err, 'no error')
+    db.put('hello', 'friend', { condition: onlyIfNull }, err => {
+      t.error(err, 'no error')
+      t.same(db.version, 2)
+      t.end()
+    })
+  })
+
+  function onlyIfNull (oldNode, newNode, cb) {
+    if (!newNode) return cb(new Error('Cannot insert a null value (use delete)'))
+    if (oldNode) return cb(null, false)
+    return cb(null, true)
+  }
+})
+
+tape('condition: delete only a certain value', function (t) {
+  const db = create()
+  db.put('hello', 'world', err => {
+    t.error(err, 'no error')
+    db.del('hello', { condition: deleteGuard('friend') }, err => {
+      t.error(err, 'no error')
+      db.get('hello', (err, node) => {
+        t.error(err, 'no error')
+        t.same(node.value, 'world')
+        doDelete()
+      })
+    })
+  })
+
+  function doDelete () {
+    db.del('hello', { condition: deleteGuard('world') }, err => {
+      t.error(err, 'no error')
+      db.get('hello', (err, node) => {
+        t.error(err, 'no error')
+        t.same(node, null)
+        t.end()
+      })
+    })
+  }
+
+  function deleteGuard (value) {
+    return function (node, cb) {
+      if (node === value) return cb(null, true)
+      return cb(null, false)
+    }
+  }
+})
+
+tape('condition: async condition', function (t) {
+  const db = create()
+  db.put('hello', 'world', { condition: afterWork }, err => {
+    t.error(err, 'no error')
+    db.put('hello', 'world', { condition: afterWork }, err => {
+      t.error(err, 'no error')
+      t.same(db.version, 3)
+      db.get('hello', (err, node) => {
+        t.error(err, 'no error')
+        t.same(node.value, 'world')
+        t.end()
+      })
+    })
+  })
+
+  function afterWork (oldNode, newNode, cb) {
+    setTimeout(() => {
+      return cb(null, true)
+    }, 200)
+  }
+})


### PR DESCRIPTION
Both `put` and `del` now:
1. Accept options instead of a fixed set of arguments.
2. Accept a `condition` argument, which is a asynchronous function that decides if a put/del should complete based on a) the current value of a node and b) the value being updated or deleted (atomic compare and swap).



