### PR TITLE
Condition function key bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,33 @@ If you set `options.feed` then you can set `storage` to null.
 Lookup a key. Returns a result node if found or `null` otherwise.
 Options are passed through to hypercore's get method.
 
-#### `db.put(key, value, [callback])`
+#### `db.put(key, value, [options], [callback])`
 
 Insert a value
 
-#### `db.del(key, [callback])`
+Options can include:
+```js
+{
+  condition: function (oldNode, newNode, cb(err, bool)) { ... } 
+}
+```
+The optional `condition` function provides atomic compare-and-swap semantics, allowing you to optionally abort a put based on the current and intended node values.
+The condition callback should be used as follows:
+1. `cb(new Error(...))`: Abort with an error that will be forwarded through the `put`.
+2. `cb(null, false)`: Abort the put, but do not produce an error.
+3. `cb(null, true)`: Proceed with the put.
+
+#### `db.del(key, [options], [callback])`
 
 Delete a key from the database.
+
+Options can include:
+```js
+{
+  condition: function (oldNode, cb(err, bool)) { ... }
+}
+```
+The optional `condition` function behaves the same as the one in `put`, minus the `newNode` parameter (since this is a deletion).
 
 #### `db.batch(batch, [callback])`
 

--- a/lib/del.js
+++ b/lib/del.js
@@ -48,7 +48,7 @@ Delete.prototype._splice = function (closest, node) {
   const val = closest ? closest.value : null
   const self = this
 
-  if (this._condition) this._condition(node.value, oncondition)
+  if (this._condition) this._condition(node, oncondition)
   else del()
 
   function oncondition (err, proceed) {

--- a/lib/put.js
+++ b/lib/put.js
@@ -13,6 +13,7 @@ function Put (db, key, value, { batch, del, condition = null }, cb) {
   this._pending = 0
   this._del = del
   this._finalized = false
+  this._head = null
 
   if (this._batch) this._update(0, this._batch.head())
   else if (this._del) this._start()
@@ -32,12 +33,12 @@ Put.prototype._start = function () {
   this._db.head(onhead)
 
   function onhead (err, head) {
-    if (err) return self._finalize(err, null)
+    if (err) return self._finalize(err)
     self._update(0, head)
   }
 }
 
-Put.prototype._finalize = function (err, lastNode) {
+Put.prototype._finalize = function (err) {
   const self = this
 
   this._finalized = true
@@ -49,7 +50,8 @@ Put.prototype._finalize = function (err, lastNode) {
   if (this._error) err = this._error
   if (err) return done(err)
 
-  if (this._condition) this._condition(lastNode, this._node, oncondition)
+  if (this._head && this._head.key !== this._node.key) this._head = null
+  if (this._condition) this._condition(this._head, this._node, oncondition)
   else insert()
 
   function oncondition (err, proceed) {
@@ -130,7 +132,9 @@ Put.prototype._update = function (i, head) {
     return this._updateHead(i, seq)
   }
 
-  this._finalize(null, head)
+  this._head = head
+
+  this._finalize(null)
 }
 
 Put.prototype._get = function (seq, cb) {

--- a/test/conditions.js
+++ b/test/conditions.js
@@ -62,7 +62,15 @@ tape('condition: two keys with same siphash', function (t) {
     db.put('mpomeiehc', 'b', { condition: onlyIfNull }, function (err) {
       t.error(err, 'no error')
       t.same(db.version, 3)
-      t.end()
+      db.get('mpomeiehc', function (err, node) {
+        t.error(err, 'no error')
+        t.same(node.value, 'b')
+        db.get('idgcmnmna', function (err, node) {
+          t.error(err, 'no error')
+          t.same(node.value, 'a')
+          t.end()
+        })
+      })
     })
   })
 

--- a/test/conditions.js
+++ b/test/conditions.js
@@ -38,6 +38,41 @@ tape('condition: put only if the value is null', function (t) {
   }
 })
 
+tape('condition: put only if value is null, nested paths', function (t) {
+  const db = create()
+  db.put('/a/b', 'world', { condition: onlyIfNull }, err => {
+    t.error(err, 'no error')
+    db.put('/a/b/c', 'friend', { condition: onlyIfNull }, err => {
+      t.error(err, 'no error')
+      t.same(db.version, 3)
+      t.end()
+    })
+  })
+
+  function onlyIfNull (oldNode, newNode, cb) {
+    if (!newNode) return cb(new Error('Cannot insert a null value (use delete)'))
+    if (oldNode) return cb(null, false)
+    return cb(null, true)
+  }
+})
+
+tape('condition: two keys with same siphash', function (t) {
+  const db = create()
+  db.put('idgcmnmna', 'a', function () {
+    db.put('mpomeiehc', 'b', { condition: onlyIfNull }, function (err) {
+      t.error(err, 'no error')
+      t.same(db.version, 3)
+      t.end()
+    })
+  })
+
+  function onlyIfNull (oldNode, newNode, cb) {
+    if (!newNode) return cb(new Error('Cannot insert a null value (use delete)'))
+    if (oldNode) return cb(null, false)
+    return cb(null, true)
+  }
+})
+
 tape('condition: delete only a certain value', function (t) {
   const db = create()
   db.put('hello', 'world', err => {
@@ -57,7 +92,7 @@ tape('condition: delete only a certain value', function (t) {
       t.error(err, 'no error')
       db.get('hello', (err, node) => {
         t.error(err, 'no error')
-        t.same(node, null)
+        t.true(node === null)
         t.end()
       })
     })
@@ -65,7 +100,7 @@ tape('condition: delete only a certain value', function (t) {
 
   function deleteGuard (value) {
     return function (node, cb) {
-      if (node === value) return cb(null, true)
+      if (node && node.value === value) return cb(null, true)
       return cb(null, false)
     }
   }


### PR DESCRIPTION
If a new node is being created within a parent directory, the `put` condition function will currently be called with the parent as `oldNode`. It's necessary to check if the keys match.

This is not the case with `del`, since in `_splice(closest, node)`, we only care about the value of `node`, which is guaranteed to have the key that's being deleted (if it exists).