### PR TITLE
[WIP] Add valueEncoding option to get/put/batch

### DIFF
--- a/index.js
+++ b/index.js
@@ -208,7 +208,7 @@ HyperTrie.prototype.getBySeq = function (seq, opts, cb) {
   if (seq < 1) return process.nextTick(cb, null, null)
 
   const self = this
-  this.feed.get(seq, { ...opts, valueEncoding: 'binary' }, onnode)
+  this.feed.get(seq, Object.assign({}, opts, { valueEncoding: 'binary' }), onnode)
 
   function onnode (err, val) {
     if (err) return cb(err)

--- a/lib/batch.js
+++ b/lib/batch.js
@@ -70,8 +70,8 @@ Batch.prototype._update = function () {
     if (i === self._ops.length) return self._finalize(null)
     if (head) self._head = head
 
-    const {type, key, value, hidden} = self._ops[i++]
+    const {type, key, value, hidden, valueEncoding} = self._ops[i++]
     if (type === 'del') self._op = new Delete(self._db, key, { batch: self, hidden }, loop)
-    else self._op = new Put(self._db, key, value === undefined ? null : value, { batch: self, del: 0, hidden }, loop)
+    else self._op = new Put(self._db, key, value === undefined ? null : value, { batch: self, del: 0, hidden, valueEncoding }, loop)
   }
 }

--- a/lib/get.js
+++ b/lib/get.js
@@ -1,3 +1,4 @@
+const codecs = require('codecs')
 const Node = require('./node')
 
 module.exports = Get
@@ -11,14 +12,15 @@ function Get (db, key, opts, cb) {
   this._prefix = !!(opts && opts.prefix)
   this._length = this._node.length - (this._prefix ? 1 : 0)
   this._onnode = (opts && opts.onnode) || null
-  this._options = opts ? { wait: opts.wait, timeout: opts.timeout } : null
+  this._options = opts ? { wait: opts.wait, timeout: opts.timeout, valueEncoding: opts.valueEncoding } : { valueEncoding: this._db.valueEncoding }
+  if (typeof this._options.valueEncoding === 'string') this._options.valueEncoding = codecs(this._options.valueEncoding)
 
   this._start()
 }
 
 Get.prototype._start = function () {
   const self = this
-  this._db.head(onhead)
+  this._db.head(this._options, onhead)
 
   function onhead (err, head) {
     if (err) return self._callback(err, null)

--- a/lib/put.js
+++ b/lib/put.js
@@ -1,10 +1,12 @@
+const codecs = require('codecs')
 const Node = require('./node')
 
 module.exports = Put
 
-function Put (db, key, value, { batch, del, condition = null, hidden = false }, cb) {
+function Put (db, key, value, { batch, del, condition = null, hidden = false, valueEncoding }, cb) {
+  if (valueEncoding && typeof valueEncoding === 'string') valueEncoding = codecs(valueEncoding)
   this._db = db
-  this._node = new Node({key, value, hidden}, 0, db.valueEncoding)
+  this._node = new Node({key, value, hidden}, 0, valueEncoding || db.valueEncoding)
   this._callback = cb
   this._release = null
   this._batch = batch

--- a/test/hidden.js
+++ b/test/hidden.js
@@ -117,7 +117,6 @@ tape('hidden deletes', function (t) {
           t.same(node.value, 'b')
         })
         db.get('a', { hidden: true }, function (err, node) {
-          console.log(node)
           t.error(err, 'no error')
           t.same(node, null)
         })


### PR DESCRIPTION
Right now you can't have per-operation valueEncodings, which makes it impossible for applications like Hyperdrive to store non-Stat metadata in the trie's hidden namespace.

This PR adds options to `put`, `get`, and `batch` to support valueEncoding, as well as some tests. If a valueEncoding isn't specified, the default is used.