### PR TITLE
Allow to diff hidden tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,8 @@ Options include:
 ```js
 {
   skipLeftNull: false,
-  skipRightNull: false
+  skipRightNull: false,
+  hidden: false
 }
 ```
 

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -17,6 +17,7 @@ function Diff (db, checkout, prefix, opts) {
   this._left = []
   this._right = []
   this._onnode = (opts && opts.onnode) || null
+  this._hidden = !!(opts && opts.hidden)
   this._needsCheck = []
   this._skipLeftNull = !!(opts && opts.skipLeftNull)
   this._skipRightNull = !!(opts && opts.skipRightNull)
@@ -26,7 +27,7 @@ inherits(Diff, Nanoiterator)
 
 Diff.prototype._open = function (cb) {
   const self = this
-  const opts = {onnode: this._onnode, prefix: true}
+  const opts = {onnode: this._onnode, prefix: true, hidden: this._hidden}
   const get = this._db.get(this._prefix, opts, function (err, a) {
     if (err) return cb(err)
     self._checkout.get(self._prefix, opts, function (err, b) {

--- a/test/diff.js
+++ b/test/diff.js
@@ -223,9 +223,11 @@ tape('diff on hidden', function (t) {
       let secdiff = db.createDiffStream(0, { hidden: true })
       let pubdiff = db.createDiffStream(0)
       collect(secdiff, (err, actual) => {
+        t.error(err, 'no error')
         t.equal(actual.length, 1)
         t.equal(actual[0].key, 'secret')
         collect(pubdiff, (err, actual) => {
+          t.error(err, 'no error')
           t.equal(actual.length, 1)
           t.equal(actual[0].key, 'public')
           t.end()

--- a/test/diff.js
+++ b/test/diff.js
@@ -214,6 +214,27 @@ tape('small diff on big db', function (t) {
   }
 })
 
+tape('diff on hidden', function (t) {
+  const db = create()
+  db.put('secret', 'hyper', { hidden: true }, err => {
+    t.error(err, 'no error')
+    db.put('public', 'knowledge', err => {
+      t.error(err, 'no error')
+      let secdiff = db.createDiffStream(0, { hidden: true })
+      let pubdiff = db.createDiffStream(0)
+      collect(secdiff, (err, actual) => {
+        t.equal(actual.length, 1)
+        t.equal(actual[0].key, 'secret')
+        collect(pubdiff, (err, actual) => {
+          t.equal(actual.length, 1)
+          t.equal(actual[0].key, 'public')
+          t.end()
+        })
+      })
+    })
+  })
+})
+
 function range (n) {
   return Array(n).join('.').split('.').map((_, i) => '' + i).map(kv)
 }


### PR DESCRIPTION
This adds a `hidden` option to `diff` to allow to to diff the hidden tree.