### PR TITLE
Hypercore 8 Upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 sudo: false
 node_js:
-  - 6
-  - 8
-  - 10
+  - "node"
+  - "lts/*"
+  - "10"
+  - "8"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Create a new database. Options include:
 ```
 {
   feed: aHypercore, // use this feed instead of loading storage
-  valueEncoding: 'json' // set value encoding
+  valueEncoding: 'json', // set value encoding
+  alwaysUpdate: true // perform an ifAvailable update prior to every head operation
 }
 ```
 
@@ -124,9 +125,11 @@ Returns a new db instance checked out at the version specified.
 
 Same as checkout but just returns the latest version as a checkout.
 
-#### `stream = db.replicate([options])`
+#### `stream = db.replicate(isInitiator, [options])`
 
 Returns a hypercore replication stream for the db. Pipe this together with another hypertrie instance.
+
+Replicate takes an `isInitiator` boolean which is used to indicate if this replication stream is the passive/active replicator.
 
 All options are forwarded to hypercores replicate method.
 

--- a/index.js
+++ b/index.js
@@ -110,8 +110,8 @@ HyperTrie.prototype.setMetadata = function (metadata) {
   this.metadata = metadata
 }
 
-HyperTrie.prototype.replicate = function (opts) {
-  return this.feed.replicate(opts)
+HyperTrie.prototype.replicate = function (isInitiator, opts) {
+  return this.feed.replicate(isInitiator, opts)
 }
 
 HyperTrie.prototype.checkout = function (version) {

--- a/index.js
+++ b/index.js
@@ -130,12 +130,15 @@ HyperTrie.prototype.snapshot = function () {
 HyperTrie.prototype.head = function (cb) {
   const self = this
 
+  console.log('IN HEAD, feed:', this.feed)
   if (!this.opened) return readyAndHead(this, cb)
   if (this._checkout !== 0) return this.getBySeq(this._checkout - 1, cb)
+  console.log('in head, alwaysUpdate:', this.alwaysUpdate)
   if (this.alwaysUpdate) this.feed.update({ hash: false, ifAvailable: true }, onupdated)
   else process.nextTick(onupdated)
 
   function onupdated () {
+    console.log('in onupdated')
     if (self.feed.length < 2) return cb(null, null)
     self.getBySeq(self.feed.length - 1, cb)
   }

--- a/index.js
+++ b/index.js
@@ -130,15 +130,12 @@ HyperTrie.prototype.snapshot = function () {
 HyperTrie.prototype.head = function (cb) {
   const self = this
 
-  console.log('IN HEAD, feed:', this.feed)
   if (!this.opened) return readyAndHead(this, cb)
   if (this._checkout !== 0) return this.getBySeq(this._checkout - 1, cb)
-  console.log('in head, alwaysUpdate:', this.alwaysUpdate)
   if (this.alwaysUpdate) this.feed.update({ hash: false, ifAvailable: true }, onupdated)
   else process.nextTick(onupdated)
 
   function onupdated () {
-    console.log('in onupdated')
     if (self.feed.length < 2) return cb(null, null)
     self.getBySeq(self.feed.length - 1, cb)
   }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "bulk-write-stream": "^1.1.4",
     "codecs": "^2.0.0",
-    "hypercore": "^7.7.0",
+    "hypercore": "^8.0.0",
     "inherits": "^2.0.3",
     "inspect-custom-symbol": "^1.1.0",
     "is-options": "^1.0.1",
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "compare": "^2.0.0",
-    "hypercore-protocol": "^6.12.0",
+    "hypercore-protocol": "^7.1.1",
     "protocol-buffers": "^4.0.4",
     "random-access-memory": "^3.0.0",
     "standard": "^11.0.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "bulk-write-stream": "^1.1.4",
     "codecs": "^2.0.0",
-    "hypercore": "^7.0.0",
+    "hypercore": "^7.7.0",
     "inherits": "^2.0.3",
     "inspect-custom-symbol": "^1.1.0",
     "is-options": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "compare": "^2.0.0",
+    "hypercore-protocol": "^6.12.0",
     "protocol-buffers": "^4.0.4",
     "random-access-memory": "^3.0.0",
     "standard": "^11.0.1",

--- a/test/update.js
+++ b/test/update.js
@@ -37,10 +37,16 @@ tape('get with alwaysUpdate will wait for an update', t => {
   })
 })
 
-tape('(bug) replication with an empty peer fails without exiting', t => {
+tape('replication with an empty peer is not problematic', t => {
   const trie1 = create({ alwaysUpdate: true })
   const emptyPeer = {
-    replicate: opts => new HypercoreProtocol(false, { ...opts, live: true })
+    replicate: (isInitiator, opts) => {
+      const stream = new HypercoreProtocol(isInitiator, { ...opts, live: true })
+      stream.on('discovery-key', dkey => {
+        stream.close(dkey)
+      })
+      return stream
+    }
   }
   var trie2 = null
 

--- a/test/update.js
+++ b/test/update.js
@@ -1,6 +1,6 @@
 const tape = require('tape')
 const create = require('./helpers/create')
-const protocol = require('hypercore-protocol')
+const HypercoreProtocol = require('hypercore-protocol')
 
 tape('get without alwaysUpdate returns null', t => {
   const trie1 = create()
@@ -15,7 +15,7 @@ tape('get without alwaysUpdate returns null', t => {
         t.end()
       })
     })
-    replicate(trie1, trie2)
+    replicate(trie1, trie2, { live: true })
   })
 })
 
@@ -40,7 +40,7 @@ tape('get with alwaysUpdate will wait for an update', t => {
 tape('(bug) replication with an empty peer fails without exiting', t => {
   const trie1 = create({ alwaysUpdate: true })
   const emptyPeer = {
-    replicate: opts => protocol({ ...opts, live: true, encrypt: false })
+    replicate: opts => new HypercoreProtocol(false, { ...opts, live: true })
   }
   var trie2 = null
 
@@ -60,6 +60,6 @@ tape('(bug) replication with an empty peer fails without exiting', t => {
 })
 
 function replicate (trie1, trie2, opts) {
-  const stream = trie1.replicate(opts)
-  return stream.pipe(trie2.replicate(opts)).pipe(stream)
+  const stream = trie1.replicate(true, opts)
+  return stream.pipe(trie2.replicate(false, opts)).pipe(stream)
 }

--- a/test/update.js
+++ b/test/update.js
@@ -1,0 +1,42 @@
+const tape = require('tape')
+const create = require('./helpers/create')
+
+tape('get without alwaysUpdate returns null', t => {
+  const trie1 = create()
+  var trie2 = null
+
+  trie1.ready(() => {
+    trie2 = create(trie1.key)
+    trie1.put('a', 'b', () => {
+      trie2.get('a', (err, node) => {
+        t.error(err, 'no error')
+        t.same(node, null)
+        t.end()
+      })
+    })
+    replicate(trie1, trie2)
+  })
+})
+
+tape('get with alwaysUpdate will wait for an update', t => {
+  const trie1 = create({ alwaysUpdate: true })
+  var trie2 = null
+
+  trie1.ready(() => {
+    trie2 = create(trie1.key, { alwaysUpdate: true, valueEncoding: 'utf8' })
+    trie1.put('a', 'b', () => {
+      trie2.get('a', (err, node) => {
+        t.error(err, 'no error')
+        t.same(node.key, 'a')
+        t.same(node.value, 'b')
+        t.end()
+      })
+    })
+    replicate(trie1, trie2)
+  })
+})
+
+function replicate (trie1, trie2, opts) {
+  const stream = trie1.replicate(opts)
+  return stream.pipe(trie2.replicate(opts)).pipe(stream)
+}

--- a/test/watch.js
+++ b/test/watch.js
@@ -74,8 +74,8 @@ tape('remote watch', function (t) {
         t.end()
       })
 
-      const stream = db.replicate()
-      stream.pipe(clone.replicate()).pipe(stream)
+      const stream = db.replicate(true)
+      stream.pipe(clone.replicate(false)).pipe(stream)
     })
   })
 })


### PR DESCRIPTION
This PR updates the `replicate` API to support Hypercore v8. It also includes the top-level `alwaysUpdate`, which will perform an `update({ ifAvailable: true }, ...)` before every `head` operation.