### PR TITLE
Update loop in sparse-mode watch

### DIFF
--- a/lib/watch.js
+++ b/lib/watch.js
@@ -15,9 +15,23 @@ function Watch (db, prefix, onchange) {
   this._kicking = false
   this._index = 0
 
+  const self = this
+  const feed = this._db.feed
+  const watchers = this._db._watchers
+
   if (onchange) this.on('change', onchange)
-  set.add(this._db._watchers, this)
+  set.add(watchers, this)
   this.update()
+
+  if (watchers.length === 1 && feed.sparse) {
+    feedUpdateLoop()
+  }
+
+  function feedUpdateLoop () {
+    if (self._destroyed) return
+    // TODO: Expose a way to cancel this update when the watcher is destroyed, since it is not ifAvailable.
+    feed.update(feedUpdateLoop)
+  }
 }
 
 inherits(Watch, events.EventEmitter)

--- a/test/watch.js
+++ b/test/watch.js
@@ -97,7 +97,6 @@ tape('remote watch with sparse mode and live replication', function (t) {
       })
 
       setTimeout(function () {
-        console.log('putting')
         db.put('hello', 'world')
       }, 50)
     })


### PR DESCRIPTION
The first time a watcher is registered on a sparse-mode trie, it should initiate an update loop. If it does not, then a remote write that happens after a delay will not trigger the `onchange` listener.

This PR also includes a test that will fail without the update loop.