### PR TITLE
Add a hash option

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,7 +143,8 @@ HyperTrie.prototype.head = function (cb) {
 
   function onnode (err, node) {
     if (err) return cb(err)
-    return cb(null, node.final())
+    if (node) node = node.final()
+    return cb(null, node)
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -187,9 +187,6 @@ HyperTrie.prototype.createDiffStream = function (other, prefix, opts) {
 
 HyperTrie.prototype.get = function (key, opts, cb) {
   if (typeof opts === 'function') return this.get(key, null, opts)
-  opts = Object.assign({}, opts, {
-    hash: this.hash
-  })
   return new Get(this, key, opts, cb)
 }
 
@@ -199,15 +196,14 @@ HyperTrie.prototype.watch = function (key, onchange) {
 }
 
 HyperTrie.prototype.batch = function (ops, cb) {
-  return new Batch(this, ops, { hash: this.hash }, cb || noop)
+  return new Batch(this, ops, cb || noop)
 }
 
 HyperTrie.prototype.put = function (key, value, opts, cb) {
   if (typeof opts === 'function') return this.put(key, value, null, opts)
   opts = Object.assign({}, opts, {
     batch: null,
-    del: 0,
-    hash: this.hash
+    del: 0
   })
   return new Put(this, key, value, opts, cb || noop)
 }
@@ -215,7 +211,6 @@ HyperTrie.prototype.put = function (key, value, opts, cb) {
 HyperTrie.prototype.del = function (key, opts, cb) {
   if (typeof opts === 'function') return this.del(key, null, opts)
   opts = Object.assign({}, opts, {
-    hash: this.hash,
     batch: null
   })
   return new Delete(this, key, opts, cb)

--- a/index.js
+++ b/index.js
@@ -132,13 +132,18 @@ HyperTrie.prototype.head = function (cb) {
   const self = this
 
   if (!this.opened) return readyAndHead(this, cb)
-  if (this._checkout !== 0) return this.getBySeq(this._checkout - 1, cb)
+  if (this._checkout !== 0) return this.getBySeq(this._checkout - 1, onnode)
   if (this.alwaysUpdate) this.feed.update({ hash: false, ifAvailable: true }, onupdated)
   else process.nextTick(onupdated)
 
   function onupdated () {
     if (self.feed.length < 2) return cb(null, null)
-    self.getBySeq(self.feed.length - 1, cb)
+    self.getBySeq(self.feed.length - 1, onnode)
+  }
+
+  function onnode (err, node) {
+    if (err) return cb(err)
+    return cb(null, node.final())
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -132,19 +132,13 @@ HyperTrie.prototype.head = function (cb) {
   const self = this
 
   if (!this.opened) return readyAndHead(this, cb)
-  if (this._checkout !== 0) return this.getBySeq(this._checkout - 1, onnode)
+  if (this._checkout !== 0) return this.getBySeq(this._checkout - 1, cb)
   if (this.alwaysUpdate) this.feed.update({ hash: false, ifAvailable: true }, onupdated)
   else process.nextTick(onupdated)
 
   function onupdated () {
     if (self.feed.length < 2) return cb(null, null)
-    self.getBySeq(self.feed.length - 1, onnode)
-  }
-
-  function onnode (err, node) {
-    if (err) return cb(err)
-    if (node) node = node.final()
-    return cb(null, node)
+    self.getBySeq(self.feed.length - 1, cb)
   }
 }
 
@@ -205,7 +199,7 @@ HyperTrie.prototype.watch = function (key, onchange) {
 }
 
 HyperTrie.prototype.batch = function (ops, cb) {
-  return new Batch(this, ops, cb || noop)
+  return new Batch(this, ops, { hash: this.hash }, cb || noop)
 }
 
 HyperTrie.prototype.put = function (key, value, opts, cb) {

--- a/lib/batch.js
+++ b/lib/batch.js
@@ -3,9 +3,10 @@ const Delete = require('./del')
 
 module.exports = Batch
 
-function Batch (db, ops, cb) {
+function Batch (db, ops, opts, cb) {
   this._db = db
   this._ops = ops
+  this._hash = opts.hash
   this._callback = cb
   this._head = null
   this._nodes = []
@@ -72,7 +73,7 @@ Batch.prototype._update = function () {
     if (head) self._head = head
 
     const {type, key, value, hidden, flags} = self._ops[i++]
-    if (type === 'del') self._op = new Delete(self._db, key, { batch: self, hidden }, loop)
-    else self._op = new Put(self._db, key, value === undefined ? null : value, { batch: self, del: 0, hidden, flags }, loop)
+    if (type === 'del') self._op = new Delete(self._db, key, { hash: self._hash, batch: self, hidden }, loop)
+    else self._op = new Put(self._db, key, value === undefined ? null : value, { hash: self._hash, batch: self, del: 0, hidden, flags }, loop)
   }
 }

--- a/lib/batch.js
+++ b/lib/batch.js
@@ -3,10 +3,9 @@ const Delete = require('./del')
 
 module.exports = Batch
 
-function Batch (db, ops, opts, cb) {
+function Batch (db, ops, cb) {
   this._db = db
   this._ops = ops
-  this._hash = opts.hash
   this._callback = cb
   this._head = null
   this._nodes = []
@@ -73,7 +72,7 @@ Batch.prototype._update = function () {
     if (head) self._head = head
 
     const {type, key, value, hidden, flags} = self._ops[i++]
-    if (type === 'del') self._op = new Delete(self._db, key, { hash: self._hash, batch: self, hidden }, loop)
-    else self._op = new Put(self._db, key, value === undefined ? null : value, { hash: self._hash, batch: self, del: 0, hidden, flags }, loop)
+    if (type === 'del') self._op = new Delete(self._db, key, { batch: self, hidden }, loop)
+    else self._op = new Put(self._db, key, value === undefined ? null : value, { batch: self, del: 0, hidden, flags }, loop)
   }
 }

--- a/lib/del.js
+++ b/lib/del.js
@@ -3,7 +3,7 @@ const Node = require('./node')
 
 module.exports = Delete
 
-function Delete (db, key, { batch, condition = null, hidden = false, closest = false }, cb) {
+function Delete (db, key, { hash, batch, condition = null, hidden = false, closest = false }, cb) {
   this._db = db
   this._key = key
   this._callback = cb

--- a/lib/del.js
+++ b/lib/del.js
@@ -10,8 +10,9 @@ function Delete (db, key, { hash, batch, condition = null, hidden = false, close
   this._release = null
   this._put = null
   this._batch = batch
+  this._hash = hash
   this._condition = condition
-  this._node = new Node({key, flags: hidden ? Node.Flags.HIDDEN : 0})
+  this._node = new Node({key, flags: hidden ? Node.Flags.HIDDEN : 0}, null, null, hash)
   this._length = this._node.length
   this._returnClosest = closest
   this._closestNode = null
@@ -61,7 +62,7 @@ Delete.prototype._splice = function (closest, node) {
   }
 
   function del () {
-    self._put = new Put(self._db, key, null, { batch: self._batch, del: node.seq, hidden, valueBuffer, flags }, done)
+    self._put = new Put(self._db, key, null, { hash: self._hash, batch: self._batch, del: node.seq, hidden, valueBuffer, flags }, done)
   }
 
   function done (err, node) {

--- a/lib/del.js
+++ b/lib/del.js
@@ -3,16 +3,15 @@ const Node = require('./node')
 
 module.exports = Delete
 
-function Delete (db, key, { hash, batch, condition = null, hidden = false, closest = false }, cb) {
+function Delete (db, key, { batch, condition = null, hidden = false, closest = false }, cb) {
   this._db = db
   this._key = key
   this._callback = cb
   this._release = null
   this._put = null
   this._batch = batch
-  this._hash = hash
   this._condition = condition
-  this._node = new Node({key, flags: hidden ? Node.Flags.HIDDEN : 0}, null, null, hash)
+  this._node = new Node({key, flags: hidden ? Node.Flags.HIDDEN : 0}, null, null, db.hash)
   this._length = this._node.length
   this._returnClosest = closest
   this._closestNode = null
@@ -62,7 +61,7 @@ Delete.prototype._splice = function (closest, node) {
   }
 
   function del () {
-    self._put = new Put(self._db, key, null, { hash: self._hash, batch: self._batch, del: node.seq, hidden, valueBuffer, flags }, done)
+    self._put = new Put(self._db, key, null, { batch: self._batch, del: node.seq, hidden, valueBuffer, flags }, done)
   }
 
   function done (err, node) {

--- a/lib/get.js
+++ b/lib/get.js
@@ -4,7 +4,7 @@ module.exports = Get
 
 function Get (db, key, opts, cb) {
   this._db = db
-  this._node = new Node({key, flags: (opts && opts.hidden) ? Node.Flags.HIDDEN : 0}, 0, null)
+  this._node = new Node({key, flags: (opts && opts.hidden) ? Node.Flags.HIDDEN : 0}, 0, null, opts.hash)
   this._callback = cb
   this._prefix = !!(opts && opts.prefix)
   this._closest = !!(opts && opts.closest)

--- a/lib/get.js
+++ b/lib/get.js
@@ -4,7 +4,7 @@ module.exports = Get
 
 function Get (db, key, opts, cb) {
   this._db = db
-  this._node = new Node({key, flags: (opts && opts.hidden) ? Node.Flags.HIDDEN : 0}, 0, null, opts.hash)
+  this._node = new Node({key, flags: (opts && opts.hidden) ? Node.Flags.HIDDEN : 0}, 0, null, db.hash)
   this._callback = cb
   this._prefix = !!(opts && opts.prefix)
   this._closest = !!(opts && opts.closest)

--- a/lib/node.js
+++ b/lib/node.js
@@ -11,13 +11,13 @@ const Flags = {
   HIDDEN: 1
 }
 
-function Node (data, seq, enc) {
+function Node (data, seq, enc, userHash) {
   this.seq = seq || 0
   this.key = normalizeKey(data.key)
   this.value = data.value !== undefined ? data.value : null
   this.keySplit = split(this.key)
   this.flags = data.flags || 0
-  this.hash = hash(this.keySplit)
+  this.hash = userHash ? userHash(this.key) : hash(this.keySplit)
   this.trie = data.trieBuffer ? trie.decode(data.trieBuffer) : (data.trie || [])
   this.trieBuffer = null
   this.valueBuffer = data.valueBuffer || null
@@ -74,8 +74,8 @@ Node.prototype.collides = function (node, i) {
   return this.keySplit[j] !== node.keySplit[j]
 }
 
-Node.decode = function (buf, seq, enc) {
-  return new Node(messages.Node.decode(buf), seq, enc)
+Node.decode = function (buf, seq, enc, hash) {
+  return new Node(messages.Node.decode(buf), seq, enc, hash)
 }
 
 Node.terminator = function (i) {

--- a/lib/put.js
+++ b/lib/put.js
@@ -8,20 +8,19 @@ function putDefaultOptions (opts) {
     closest: false,
     hidden: false,
     valueBuffer: null,
-    flags: 0,
-    hash: null
+    flags: 0
   }, opts)
 }
 
 function Put (db, key, value, opts, cb) {
-  let { hidden, condition, valueBuffer, flags, batch, del, closest, hash } = putDefaultOptions(opts)
+  let { hidden, condition, valueBuffer, flags, batch, del, closest } = putDefaultOptions(opts)
 
   this._db = db
 
   // The flags are shifted in order to both hide the internal flags and support user-defined flags.
   flags = (flags << 8) | (hidden ? Node.Flags.HIDDEN : 0)
 
-  this._node = new Node({key, value, valueBuffer, flags}, 0, db.valueEncoding, hash)
+  this._node = new Node({key, value, valueBuffer, flags}, 0, db.valueEncoding, db.hash)
   this._callback = cb
   this._release = null
   this._batch = batch

--- a/lib/put.js
+++ b/lib/put.js
@@ -8,19 +8,20 @@ function putDefaultOptions (opts) {
     closest: false,
     hidden: false,
     valueBuffer: null,
-    flags: 0
+    flags: 0,
+    hash: null
   }, opts)
 }
 
 function Put (db, key, value, opts, cb) {
-  let { hidden, condition, valueBuffer, flags, batch, del, closest } = putDefaultOptions(opts)
+  let { hidden, condition, valueBuffer, flags, batch, del, closest, hash } = putDefaultOptions(opts)
 
   this._db = db
 
   // The flags are shifted in order to both hide the internal flags and support user-defined flags.
   flags = (flags << 8) | (hidden ? Node.Flags.HIDDEN : 0)
 
-  this._node = new Node({key, value, valueBuffer, flags}, 0, db.valueEncoding)
+  this._node = new Node({key, value, valueBuffer, flags}, 0, db.valueEncoding, hash)
   this._callback = cb
   this._release = null
   this._batch = batch

--- a/test/basic.js
+++ b/test/basic.js
@@ -528,3 +528,30 @@ tape('can support a custom hash function', function (t) {
     })
   })
 })
+
+tape('can delete with a custom hash function', function (t) {
+  const db = create(null, {
+    valueEncoding: 'utf-8',
+    hash: function (key) {
+      return Buffer.from(key)
+    }
+  })
+  db.ready(function (err) {
+    t.error(err, 'no error')
+    db.put('hello', 'world', function (err) {
+      t.error(err, 'no error')
+      db.get('hello', function (err, node) {
+        t.error(err, 'no error')
+        t.same(node.value, 'world')
+        db.del('hello', function (err) {
+          t.error(err, 'no error')
+          db.get('hello', function (err, node) {
+            t.error(err, 'no error')
+            t.false(node)
+            t.end()
+          })
+        })
+      })
+    })
+  })
+})

--- a/test/basic.js
+++ b/test/basic.js
@@ -508,3 +508,23 @@ tape('can create with metadata', function (t) {
     })
   })
 })
+
+tape('can support a custom hash function', function (t) {
+  const db = create(null, {
+    valueEncoding: 'utf-8',
+    hash: function (key) {
+      return Buffer.from(key)
+    }
+  })
+  db.ready(function (err) {
+    t.error(err, 'no error')
+    db.put('hello', 'world', function (err) {
+      t.error(err, 'no error')
+      db.get('hello', function (err, node) {
+        t.error(err, 'no error')
+        t.same(node.value, 'world')
+        t.end()
+      })
+    })
+  })
+})


### PR DESCRIPTION
This adds the ability to pass a custom hash function in as a top-level option. A user-defined hash function must have the signature `hash(key: string) -> Buffer`.