### PR TITLE
Fix closest node handling in deletions

### DIFF
--- a/lib/del.js
+++ b/lib/del.js
@@ -14,7 +14,6 @@ function Delete (db, key, { batch, condition = null, hidden = false, closest = f
   this._node = new Node({key, flags: hidden ? Node.Flags.HIDDEN : 0}, null, null, db.hash)
   this._length = this._node.length
   this._returnClosest = closest
-  this._closestNode = null
   this._closest = 0
 
   if (this._batch) this._update(0, this._batch.head())
@@ -99,7 +98,7 @@ Delete.prototype._update = function (i, head) {
 
   function terminate () {
     if (self._condition && self._returnClosest) {
-      return self._condition(self._closestNode && self._closestNode.final(), (err, proceed) => {
+      return self._condition(head && head.final(), (err, proceed) => {
         if (err) return self._finalize(err)
         return self._finalize(null, null)
       })
@@ -131,7 +130,6 @@ Delete.prototype._updateHead = function (i, seq) {
 
   function onnode (err, node) {
     if (err) return self._finalize(err, null)
-    self._closestNode = node || self._closestNode
     self._update(i + 1, node)
   }
 }


### PR DESCRIPTION
In the current implementation of deletion condition functions, if it only takes a single hop to get to the closest node, then that node will incorrectly be null.