### PR TITLE
document the history iterator's `reverse` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Options include:
   lt: seq,
   gte: seq,
   lte: seq,
+  reverse: false,
   live: false // set to true to keep iterating forever
 }
 ```


### PR DESCRIPTION
I found this nice option to rewind over a hypertrie but saw that it wasn't documented.