### PR TITLE
Watch should always wait in the update loop

### DIFF
--- a/lib/watch.js
+++ b/lib/watch.js
@@ -30,7 +30,7 @@ function Watch (db, prefix, onchange) {
   function feedUpdateLoop () {
     if (self._destroyed) return
     // TODO: Expose a way to cancel this update when the watcher is destroyed, since it is not ifAvailable.
-    feed.update(feedUpdateLoop)
+    feed.update({ ifAvailable: false }, feedUpdateLoop)
   }
 }
 


### PR DESCRIPTION
The update loop inside watch should always wait, instead of immediately terminating when `ifAvailable: true` is set as a hypercore option