### PR TITLE
Guard against null node in history. Fixes #46

### DIFF
--- a/index.js
+++ b/index.js
@@ -330,7 +330,7 @@ HyperTrie.prototype.getBySeq = function (seq, opts, cb) {
     const node = Node.decode(val, seq, self.valueEncoding, self.hash)
     self._cache.set(seq, val)
     // early exit for the key: '' nodes we write to reset the db
-    if (!node.value && !node.key) return cb(null, null)
+    if (node.value === null && node.key === '') return cb(null, null)
     cb(null, node)
   }
 }

--- a/lib/history.js
+++ b/lib/history.js
@@ -43,6 +43,7 @@ History.prototype._next = function (cb) {
 
   function done (err, node) {
     if (err) return cb(err)
+    if (!node) return cb(null, null)
     cb(null, node.final())
   }
 }


### PR DESCRIPTION
A `createHistoryStream` iterator might receive a null node leading to #46 hence we check and bailout if we receive null.

This PR also includes a more targeted check in `nodeBySeq`.